### PR TITLE
Fix GitHub workflows for new bundle structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
           ls -la dist/
           
           echo "Checking bundle files..."
-          test -f "tokens/bundle.css" && echo "✅ Tokens bundle created"
-          test -f "components/bundle.css" && echo "✅ Components bundle created"  
-          test -f "themes/bundle.css" && echo "✅ Themes bundle created"
+          test -f "dist/tokens.css" && echo "✅ Tokens bundle created"
+          test -f "dist/components.css" && echo "✅ Components bundle created"  
+          test -f "dist/themes.css" && echo "✅ Themes bundle created"
           
           echo "Checking main bundles..."
           test -f "dist/design-system.css" && echo "✅ Main CSS bundle created"
@@ -78,8 +78,8 @@ jobs:
           echo "Bundle size check..."
           wc -c dist/design-system.css | awk '{print "Main bundle: " $1 " bytes"}'
           wc -c dist/design-system.min.css | awk '{print "Minified bundle: " $1 " bytes"}'
-          wc -c tokens/bundle.css | awk '{print "Tokens bundle: " $1 " bytes"}'
-          wc -c components/bundle.css | awk '{print "Components bundle: " $1 " bytes"}'
-          wc -c themes/bundle.css | awk '{print "Themes bundle: " $1 " bytes"}'
+          wc -c dist/tokens.css | awk '{print "Tokens bundle: " $1 " bytes"}'
+          wc -c dist/components.css | awk '{print "Components bundle: " $1 " bytes"}'
+          wc -c dist/themes.css | awk '{print "Themes bundle: " $1 " bytes"}'
           
           echo "✅ All build outputs verified"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,9 +40,9 @@ jobs:
           echo "Checking build outputs before publish..."
           test -f "dist/design-system.css" || exit 1
           test -f "dist/design-system.min.css" || exit 1
-          test -f "tokens/bundle.css" || exit 1
-          test -f "components/bundle.css" || exit 1
-          test -f "themes/bundle.css" || exit 1
+          test -f "dist/tokens.css" || exit 1
+          test -f "dist/components.css" || exit 1
+          test -f "dist/themes.css" || exit 1
           
           # Check that minified version is smaller than main version
           MAIN_SIZE=$(wc -c < "dist/design-system.css")


### PR DESCRIPTION
## Summary
- Fix CI and publish workflows to use new bundle file paths in `dist/` directory
- Update file checks from old `bundle.css` paths to new consolidated structure
- Ensures workflows work correctly after build system restructure

## Changes
- **CI workflow**: Update bundle verification and size reporting paths
- **Publish workflow**: Update build quality checks for new bundle locations

## Test plan
- [ ] Verify CI workflow passes with new bundle paths
- [ ] Test publish workflow can find all required bundle files
- [ ] Confirm all build outputs are properly validated

🤖 Generated with [Claude Code](https://claude.ai/code)